### PR TITLE
Handbrake with password for web interface

### DIFF
--- a/apps/handbrake-password
+++ b/apps/handbrake-password
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# Title:      Handbrake for PlexGuide
+# Author(s):  timekills
+# URL:        https://plexguide.com - https://github.com/timekills
+# GNU:        General Public License v3.0
+################################################################################
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    # FACTS #######################################################################
+
+    - name: 'Set Known Facts'
+      set_fact:
+        pgrole: 'handbrake'
+        intport: '5800'
+        extport: '5800'
+        image: 'jlesage/handbrake:dev-latest'
+
+    # CORE (MANDATORY) ############################################################
+    - name: 'Including cron job'
+      include_tasks: '/opt/plexguide/containers/_core.yml'
+
+    # MIGRATIONS (REMOVE SECTION ON MARCH 1st) #############################################################
+    - name: 'Check for old volumes'
+      stat:
+        path: '{{path.stdout}}/{{pgrole}}'
+      register: oldcheck
+
+    - name: 'Get home variable'
+      debug: homestorage=ansible_env.HOME
+
+    # LABELS ######################################################################
+    - name: 'Adding Traefik'
+      set_fact:
+        pg_labels:
+          traefik.enable: 'true'
+          traefik.port: '{{intport}}'
+          traefik.frontend.auth.basic: "plex:$apr1$tosnCNtX$XKXnDaIiW7f0y1nwmd.KL0"
+          traefik.frontend.rule: 'Host:{{pgrole}}.{{domain.stdout}},{{tldset}}'
+
+    - name: 'Setting PG Volumes'
+      set_fact:
+        pg_volumes:
+          - '/opt/appdata/{{pgrole}}/config:/config:rw'
+          - '/:/storage:ro'
+          - '{{path.stdout}}:{{path.stdout}}'
+          - '/mnt/unionfs:/mnt/unionfs'
+          - '{{path.stdout}}/{{pgrole}}/watch/Very_Fast_1080p30:/watch:rw'
+          - '{{path.stdout}}/{{pgrole}}/watch/HQ_1080p30_Surround:/watch2:rw'
+          - '{{path.stdout}}/{{pgrole}}/watch/1080mkv:/watch3:rw'
+          - '{{path.stdout}}/{{pgrole}}/complete/:/output:rw'
+          - '/dev/dri:/dev/dri:rw'
+          - '/etc/localtime:/etc/localtime:ro'
+
+    - name: 'Setting PG ENV'
+      set_fact:
+        pg_env:
+          USER_ID: 1000
+          GROUP_ID: 1000
+          AUTOMATED_CONVERSION_PRESET: "Very Fast 1080p30"
+          AUTOMATED_CONVERSION_FORMAT: "mp4"
+          AUTOMATED_CONVERSION_PRESET_2: "HQ 1080p30 Surround"
+          AUTOMATED_CONVERSION_FORMAT_2: "mp4"
+          AUTOMATED_CONVERSION_PRESET_3: "H.264 MKV 1080p30"
+          AUTOMATED_CONVERSION_FORMAT_3: "mkv"
+#          SECURE_CONNECTION: 1
+
+    # MAIN DEPLOYMENT #############################################################
+    - name: 'Create watch directory for {{pgrole}}'
+      file:
+        path: '{{path.stdout}}/handbrake/watch'
+        state: directory
+        owner: 1000
+        group: 1000
+        mode: 0755
+        recurse: yes
+
+    - name: 'Create complete directory for {{pgrole}}'
+      file:
+        path: '{{path.stdout}}/handbrake/complete'
+        state: directory
+        owner: 1000
+        group: 1000
+        mode: 0755
+        recurse: yes
+
+    - name: 'Deploying {{pgrole}}'
+      docker_container:
+        name: '{{pgrole}}'
+        image: '{{image}}'
+        pull: yes
+        published_ports:
+          - '{{ports.stdout}}{{extport}}:{{intport}}'
+        volumes: '{{pg_volumes}}'
+        env: '{{pg_env}}'
+        restart_policy: unless-stopped
+        networks:
+          - name: plexguide
+            aliases:
+              - '{{pgrole}}'
+        state: started
+        labels: '{{pg_labels}}'
+
+    - name: 'Wait 6 Seconds'
+      wait_for:
+        timeout: 6
+
+    - name: Stop Container
+      docker_container:
+        name: '{{pgrole}}'
+        state: stopped
+
+    # ENDING FOR HANDBRAKE ###########################################################
+
+#    - name: 'Waiting for {{pgrole}} to initialize'
+#      wait_for:
+#        path: '/opt/appdata/{{pgrole}}/core.conf'
+#        state: present
+
+    - name: 'Configuring {{pgrole}} for first time use'
+      block:
+        - name: 'Stopping {{pgrole}}'
+          docker_container:
+            name: '{{pgrole}}'
+            state: stopped
+
+#       - name: Setting plugins directory
+#          lineinfile:
+#            path: '/opt/appdata/{{pgrole}}/core.conf'
+#            regexp: '"plugins_location"'
+#            line: '"plugins_location": "/config/plugins",'
+#            state: present
+
+        - name: Restart Container
+          docker_container:
+            name: '{{pgrole}}'
+            state: started


### PR DESCRIPTION
# handbrake-for-plexguide (username/password version)
Handbrake through web interface for PlexGuide deployment with Traefik integration and username/password security in case Google OAuth is not desired.
Includes multiple automatic presets based on folder.

# Automated directory use (from command line instead of using web interface):
Add to /mnt/handbrake/watch/Very_Fast_1080p30 folder for automatic 1080p AAC 2.0 MP4 (Very Fast)
Add to /mnt/handbrake/watch/HQ_1080p30_Surround folder for automatic HQ 1080p 5,1 MP4  (Slow)
Add to /mnt/handbrake/1080mkv folder for automatic 1080p AAC 2.0 MKV (Standard)

# Default username is plex and default password is guide

# If you want to change the username/password from default plex/guide
1. go to --> http://www.htaccesstools.com/htpasswd-generator/ and create username/password pair. It will give you the plaintext username and hashed password
2. (example username test and password test will give you test:$apr1$n22fgswn$4Wu4q/Dzc7ACcgiLaoU5d/)
3. Edit the /opt/mycontainers/handbrake.yml file (eg. sudo nano /opt/mycontainers/handbrake.yml )
4. Replace the line traefik.frontend.auth.basic: "plex:$apr1$tosnCNtX$XKXnDaIiW7f0y1nwmd.KL0" with traefik.frontend.auth.basic: "yourNewUsername:YourNewHashedPassword."  Example traefik.frontend.auth.basic: "test:$apr1$n22fgswn$4Wu4q/Dzc7ACcgiLaoU5d/"
Go to plexguide and redeploy/reinstall handbrake