### PR TITLE
Create mcmyadmin.yml

### DIFF
--- a/apps/mcmyadmin.yml
+++ b/apps/mcmyadmin.yml
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# Title:      McMyadmin2
+# Author(s):  timekills
+# URL:        https://plexguide.com - http://github.plexguide.com
+# GNU:        General Public License v3.0
+################################################################################
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    # CORE (MANDATORY) DO NOT CHANGE ###########################################
+
+    - name: 'Set Known Facts'
+      set_fact:
+        pgrole: 'mcmyadmin2'
+        intport: '8080'
+        extport: '8088'
+        image: 'linuxserver/mcmyadmin2'
+
+    - name: 'Including cron job'
+      include_tasks: '/opt/plexguide/containers/_core.yml'
+
+    # EXTRA FUNCTIONS REQUIRED BY THE ROLE #####################################
+
+    - name: 'Create scripts directory for {{pgrole}}'
+      file:
+        path: /opt/appdata/{{pgrole}}/scripts
+        state: directory
+        owner: 1000
+        group: 1000
+        mode: 0755
+
+    - name: 'Create plugins directory for {{pgrole}}'
+      file:
+        path: /opt/appdata/{{pgrole}}/plugins
+        state: directory
+        owner: 1000
+        group: 1000
+        mode: 0755
+
+    # LABELS #### KEEPS BOTTOM CLEAN ###########################################
+    - name: 'Adding Traefik'
+      set_fact:
+        pg_labels:
+          traefik.frontend.auth.forward.address: '{{gauth}}'
+          traefik.enable: 'true'
+          traefik.port: '{{intport}}'
+          traefik.frontend.rule: 'Host:mcmyadmin.{{domain.stdout}},{{tldset}}'
+
+    - name: 'Setting PG Volumes'
+      set_fact:
+        pg_volumes:
+          - '/opt/appdata/{{pgrole}}/mcmyadmin:/minecraft'
+          - '/opt/appdata/{{pgrole}}/Minecraft:/Minecraft'
+          - '{{path.stdout}}:{{path.stdout}}'
+          - '/mnt:/mnt'
+          - '/etc/localtime:/etc/localtime:ro'
+
+    - name: 'Setting PG ENV'
+      set_fact:
+        pg_env:
+          PUID: 1000
+          PGID: 1000
+
+    # MAIN SCRIPT ##############################################################
+
+    - name: 'Deploying {{pgrole}}'
+      docker_container:
+        name: '{{pgrole}}'
+        image: '{{image}}'
+        pull: yes
+        published_ports:
+          - '{{ports.stdout}}{{extport}}:{{intport}}'
+          - '25565:25565/tcp'
+          - '25566:25566/tcp'
+          - '25567:25567/tcp'
+        volumes: '{{pg_volumes}}'
+        env: '{{pg_env}}'
+        restart_policy: unless-stopped
+        networks:
+          - name: plexguide
+            aliases:
+              - '{{pgrole}}'
+        state: started
+        labels: '{{pg_labels}}'


### PR DESCRIPTION
Includes McMyadmin front end and built-in Minecraft server.
-----------------------------------------------
In order to access McMyAdmin you have to change the default username:
From SSH into the server:
1. docker exec -it mcmyadmin2 /bin/bash
2. ./minecraft/MCMA2_Linux_x86_64 /quit
3. ./minecraft/MCMA2_Linux_x86_64 -setpass changme -configonly
3. exit
4. docker stop mcmyadmin2
5. docker start mcmyadmin2
6. login with username admin and password password
6a. Yes. That's not a typo - the login will still be admin and the password will still be password until you change them in the web interface.
7. Change the password for the admin user from the McMyAdmin web interface
8. You can add a new user and delete "admin" if you want from the web interface.

Notes:
- DO NOT add "minecraft.tld" to Cloudflare if you want people to go to minecraft.tld as the game server name. You still need to add mcmyadmin to Cloudflare however.
- You can run servers on the default port (25565) and up to two additional servers on ports 25566 and 25567