### PR TITLE
Optimized JDownloader2 and created a community app for MakeMKV

### DIFF
--- a/apps/jdownloader2.yml
+++ b/apps/jdownloader2.yml
@@ -15,7 +15,7 @@
       set_fact:
         pgrole: 'jdownloader2'
         intport: '5802'
-        extport: '5802'
+        extport: '5800'
         intport2: '5902'
         extport2: '5902'
         intport3: '3129'

--- a/apps/jdownloader2.yml
+++ b/apps/jdownloader2.yml
@@ -14,8 +14,8 @@
     - name: 'Set Known Facts'
       set_fact:
         pgrole: 'jdownloader2'
-        intport: '5801'
-        extport: '5801'
+        intport: '5802'
+        extport: '5802'
         intport2: '5902'
         extport2: '5902'
         intport3: '3129'

--- a/apps/jdownloader2.yml
+++ b/apps/jdownloader2.yml
@@ -14,8 +14,8 @@
     - name: 'Set Known Facts'
       set_fact:
         pgrole: 'jdownloader2'
-        intport: '5802'
-        extport: '5800'
+        intport: '5800'
+        extport: '5802'
         intport2: '5902'
         extport2: '5902'
         intport3: '3129'

--- a/apps/jdownloader2.yml
+++ b/apps/jdownloader2.yml
@@ -14,8 +14,8 @@
     - name: 'Set Known Facts'
       set_fact:
         pgrole: 'jdownloader2'
-        intport: '5800'
-        extport: '5800'
+        intport: '5801'
+        extport: '5801'
         intport2: '5902'
         extport2: '5902'
         intport3: '3129'

--- a/apps/jdownloader2.yml
+++ b/apps/jdownloader2.yml
@@ -35,13 +35,13 @@
     - name: 'Migrations'
       block:
         - name: 'Creating new downloads location'
-          command: 'mkdir -p {{path.stdout}}/incomplete/{{pgrole}}'
+          command: 'mkdir -p {{path.stdout}}/downloads/{{pgrole}}'
 
     - name: 'Chown download folder'
-      shell: 'chown -R 1000:1000 {{path.stdout}}/incomplete/{{pgrole}}/'
+      shell: 'chown -R 1000:1000 {{path.stdout}}/downloads/{{pgrole}}/'
 
     - name: 'Chmod download folder'
-      shell: 'chmod -R 775 {{path.stdout}}/incomplete/{{pgrole}}/'
+      shell: 'chmod -R 775 {{path.stdout}}/downloads/{{pgrole}}/'
 
     - name: 'Ini Check'
       stat:
@@ -63,7 +63,7 @@
           - '/opt/appdata/{{pgrole}}:/config'
           - '{{path.stdout}}:{{path.stdout}}'
           - '/mnt/unionfs:/unionfs'
-          - '{{path.stdout}}/incomplete/{{pgrole}}/:/output:rw'
+          - '{{path.stdout}}/downloads/{{pgrole}}/:/output:rw'
           - '/etc/localtime:/etc/localtime:ro'
 
     - name: 'Setting PG ENV'

--- a/apps/makemkv.yml
+++ b/apps/makemkv.yml
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Title:      MakeMKV for PlexGuide
+# Author(s):  rla999
+# URL:        https://plexguide.com - https://github.com/rla999/makemkv-for-plexguide/
+# GNU:        General Public License v3.0
+################################################################################
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    # FACTS #######################################################################
+
+    - name: 'Set Known Facts'
+      set_fact:
+        pgrole: 'makemkv'
+        intport: '5800'
+        extport: '5801'
+        intport2: '5903'
+        extport2: '5903'
+        image: 'jlesage/makemkv'
+
+    # CORE (MANDATORY) ############################################################
+    - name: 'Including cron job'
+      include_tasks: '/opt/plexguide/containers/_core.yml'
+
+    # MIGRATIONS (REMOVE SECTION ON MARCH 1st) #############################################################
+    - name: 'Check for old volumes'
+      stat:
+        path: '{{path.stdout}}/{{pgrole}}'
+      register: oldcheck
+
+    - name: 'Migrations'
+      block:
+        - name: 'Creating new downloads location'
+          command: 'mkdir -p {{path.stdout}}/downloads/{{pgrole}}'
+
+    - name: 'Chown download folder'
+      shell: 'chown -R 1000:1000 {{path.stdout}}/downloads/{{pgrole}}/'
+
+    - name: 'Chmod download folder'
+      shell: 'chmod -R 775 {{path.stdout}}/downloads/{{pgrole}}/'
+
+    - name: 'Ini Check'
+      stat:
+        path: /opt/appdata/{{pgrole}}/core.conf
+      register: inicheck
+
+    # LABELS ######################################################################
+    - name: 'Adding Traefik'
+      set_fact:
+        pg_labels:
+          traefik.enable: 'true'
+          traefik.port: '{{intport}}'
+          traefik.frontend.auth.forward.address: '{{gauth}}'
+          traefik.frontend.rule: 'Host:{{pgrole}}.{{domain.stdout}},{{tldset}}'
+          
+    - name: 'Setting PG Volumes'
+      set_fact:
+        pg_volumes:
+          - '/opt/appdata/{{pgrole}}:/config'
+          - '{{path.stdout}}:{{path.stdout}}'
+          - '/mnt/unionfs:/unionfs'
+          - '{{path.stdout}}/downloads/{{pgrole}}/:/output:rw'
+          - '/etc/localtime:/etc/localtime:ro'
+
+    - name: 'Setting PG ENV'
+      set_fact:
+        pg_env:
+          UID: 1000
+          GID: 1000
+          MAKEMKV_KEY: BETA
+          AUTO_DISC_RIPPER: 0
+          ENABLE_CJK_FONT: 1
+          CLEAN_TMP_DIR: 1
+          KEEP_APP_RUNNING: 1
+
+    # MAIN DEPLOYMENT #############################################################
+
+    - name: 'Deploying {{pgrole}}'
+      docker_container:
+        name: '{{pgrole}}'
+        image: '{{image}}'
+        pull: yes
+        published_ports:
+          - '{{ports.stdout}}{{extport}}:{{intport}}'
+        volumes: '{{pg_volumes}}'
+        env: '{{pg_env}}'
+        restart_policy: unless-stopped
+        networks:
+          - name: plexguide
+            aliases:
+              - '{{pgrole}}'
+        state: started
+        labels: '{{pg_labels}}'
+
+    - name: 'Wait 7 Seconds'
+      wait_for:
+        timeout: 7
+
+    - name: Stop Container
+      docker_container:
+        name: '{{pgrole}}'
+        state: stopped
+
+    # ENDING FOR JDOWNLOADER2 ###########################################################
+
+#    - name: 'Waiting for {{pgrole}} to initialize'
+#      wait_for:
+#        path: '/opt/appdata/{{pgrole}}/core.conf'
+#        state: present
+
+    - name: 'Configuring {{pgrole}} for first time use'
+      block:
+        - name: 'Stopping {{pgrole}}'
+          docker_container:
+            name: '{{pgrole}}'
+            state: stopped
+
+        - name: Restart Container
+          docker_container:
+            name: '{{pgrole}}'
+            state: started
+
+      when: not inicheck.stat.exists


### PR DESCRIPTION
I created a community app for MakeMKV. It is confirmed to work with OAuth and should not cause port conflict for most people even if they are running handbrake and/or jdownloader2.
[](https://github.com/rla999/makemkv-for-plexguide/blob/master/README.md)
Also optimized JDownloader2 for people like myself that use multiple apps with GUIs, i.e. Handbrake, MakeMKV, etc. I changed the port to avoid conflict. That way Handbrake can use port 5800, JDownloader can use 5801, and MakeMKV can use 5802. Also changed download location so that the completed download folder is found in a similar place to those of torrent and NZB programs.