### PR TITLE
Adding Gitea- self hosted Git

### DIFF
--- a/apps/gitea.yml
+++ b/apps/gitea.yml
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# Title:      PlexGuide (Reference Title File)
+# Author(s):  Admin9705
+# URL:        https://plexguide.com - http://github.plexguide.com
+# GNU:        General Public License v3.0
+################################################################################
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    # FACTS #######################################################################DONE####
+    - name: 'Set Known Facts'
+      set_fact:
+        pgrole: 'git'
+        intport: '3000'
+        extport: '9898'
+        intport2: '22'       ##for SSH
+        extport2: '222'
+        
+        image: 'gitea/gitea'
+
+    # CORE (MANDATORY) ############################################################DONE####
+    - name: 'Including cron job'
+      include_tasks: '/opt/plexguide/containers/_core.yml'
+
+    # LABELS ######################################################################
+    - name: 'Adding Traefik'
+      set_fact:
+        pg_labels:
+          ##########traefik.frontend.auth.forward.address: '{{gauth}}' ##Disabled OAuth as you cant user terminal for cloning any repo
+          traefik.enable: 'true'
+          traefik.port: '{{intport}}'
+          traefik.frontend.rule: 'Host:{{pgrole}}.{{domain.stdout}},{{tldset}}'
+
+    - name: 'Setting PG Volumes'
+      set_fact:
+        pg_volumes:
+          - '/opt/appdata/{{pgrole}}:/config'
+          - '/etc/localtime:/etc/localtime:ro'
+   ###    - '/opt/appdata/git/gitea-db:/data'
+
+    - name: 'Setting PG ENV'
+      set_fact:
+        pg_env:
+          PUID: 1000
+          PGID: 1000
+     #### DB_PASSWORD: gitea
+
+    # MAIN DEPLOYMENT #############################################################
+    - name: 'Deploying {{pgrole}}'
+      docker_container:
+        name: '{{pgrole}}'
+        image: '{{image}}'
+        pull: yes
+     #   links:
+        #  - "dbgitea:idk?"
+        published_ports:
+          - '{{ports.stdout}}{{extport}}:{{intport}}'
+          - '{{ports.stdout}}{{extport2}}:{{intport2}}'
+        volumes: '{{pg_volumes}}'
+        env: '{{pg_env}}'
+        restart_policy: unless-stopped
+        networks:
+          - name: plexguide
+            aliases:
+              - '{{pgrole}}'
+        state: started
+        labels: '{{pg_labels}}'
+        
+        
+      


### PR DESCRIPTION
Hi,
I have added Gitea a self hosted Github
you can see their website [https://gitea.io](url)
Only thing is the SQL database is created inside the Docker container, so if one redeploys the app, all previous database is lost.
There is a documentation on their website to how to start with docker container [https://docs.gitea.io/en-us/install-with-docker/](url)

But being not so familiar with docker, i cant get it to work (I'm trying to make a separated Mysql/PostgreSQL ) container , and link their volumes of them (see the link above for how it is installed)

If anyone can make the db container(similar to how pg press's db container is processed), it would be great.

Anyways the container works flawlessly if db is hosted in itself and app not redeployed. Traefik is configured and available at git.domain.tld. Make sure to have the network settings shown in the attached image .
By default, the first user created becomes the admin
![gitea](https://user-images.githubusercontent.com/12170180/52331618-a5c44680-2a1e-11e9-8753-b1ccb31dd9a8.PNG)
