### PR TITLE
Fixed volume name typo in gitea

### DIFF
--- a/apps/gitea.yml
+++ b/apps/gitea.yml
@@ -36,7 +36,7 @@
     - name: 'Setting PG Volumes'
       set_fact:
         pg_volumes:
-          - '/opt/appdata/{{pgrole}}:/config'
+          - '/opt/appdata/{{pgrole}}:/data'
           - '/etc/localtime:/etc/localtime:ro'
    ###    - '/opt/appdata/git/gitea-db:/data'
 


### PR DESCRIPTION
same as title, now the volumes are mapped correctly to make any changes in the app